### PR TITLE
Fixed filters fading problem in tasks page.

### DIFF
--- a/src/Components/Tasks/TaskCard.js
+++ b/src/Components/Tasks/TaskCard.js
@@ -170,7 +170,7 @@ export default function TaskCard() {
 
   return (
     <div className='eee'>
-      <div className={classes.filter}  data-aos="fade-up-right">
+      <div className={classes.filter}>
       <FormControl component="fieldset">
       <FormLabel component="legend">Filter Tasks</FormLabel>
       <RadioGroup className={classes.filterOptions} aria-label="tasks" name="filter" value={value} onChange={handleChange}>
@@ -183,7 +183,7 @@ export default function TaskCard() {
     </div>
       {data.map((tasks, index) => (
 
-    <Card className={classes.root} color="primary"  key={index}  data-aos="fade-right" >
+    <Card className={classes.root} color="primary"  key={index}>
       <div className={classes.details}>
         <CardContent className={classes.content}>
           <Typography component="h5" variant="h5">


### PR DESCRIPTION
Fading problem fixed.

# Description

Fixed filter options fading while scrolling up the page

Fixes # (issue)

## Type of change

- [✅] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested the filter options 7-9 times and added the fix to the code.

- [✅] Test A
- [✅] Test B

* Operating System: Linux 

# Checklist:

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [✅] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings

# Video Clips:
Before Fix:
https://drive.google.com/file/d/1WPU6_hmnixR0s_Z9hoiQd3ZpZ9nsSdkl/view?usp=sharing
After Fix:
https://drive.google.com/file/d/19kJB3eCrb_re7Kls1__Pj097Ql3TDgMd/view?usp=sharing

