### PR TITLE
Fixed Filter Tasks color change.

### DIFF
--- a/src/Components/Tasks/TaskCard.js
+++ b/src/Components/Tasks/TaskCard.js
@@ -172,7 +172,7 @@ export default function TaskCard() {
     <div className='eee'>
       <div className={classes.filter}>
       <FormControl component="fieldset">
-      <FormLabel component="legend">Filter Tasks</FormLabel>
+      <FormLabel component="legend" style={{ color: 'white' }}>Filter Tasks</FormLabel>
       <RadioGroup className={classes.filterOptions} aria-label="tasks" name="filter" value={value} onChange={handleChange}>
         <FormControlLabel value="All" control={<Radio color='secondary' />} label="All Tasks" />
         <FormControlLabel value="Code" control={<Radio color='secondary'/>} label="Coding" />


### PR DESCRIPTION
# Description

When changing the filter type the word ```Filter Tasks``` change the color to gray. 

Fixes # (issue)

## Type of change

- [✅] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tried to change the filter type 3-4 times and every time I do that Filter Tasks word's color change to gray. 

- [✅] Test A
- [✅] Test B

**Test Configuration**:
* Operating System: Linux

# Checklist:

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings

# ScreenShots:
Before Fix:
![image](https://user-images.githubusercontent.com/57533877/128998921-e3d69592-2d2c-4e47-a22e-02eb8115a33b.png)
After Fix:
![image](https://user-images.githubusercontent.com/57533877/128998976-898474aa-7c5d-44c8-8614-194197448d4e.png)

