### PR TITLE
Solved the typo in the Home page

### DIFF
--- a/src/Components/Home/Categories.js
+++ b/src/Components/Home/Categories.js
@@ -94,7 +94,7 @@ backgroundSize: 'cover',
       />
       <CardContent className={classes.subContent}>
         <Typography variant="h6" className={classes.subText}>
-        Learn to talk to you computer and make amazing websites, games, apps and many more that everyone can use by the power of programming
+        Learn to talk to your computer and make amazing websites, games, apps and many more that everyone can use by the power of programming
         </Typography>
       </CardContent>
     </Card>


### PR DESCRIPTION
# Description

There was a grammatical mistake with the "CODE" category's description - "Learn to talk to ****you** computer** and make amazing websites, games, apps and many more that everyone can use by the power of programming"

I've also reported this bug in the [issues section ](https://github.com/acicts/BITS21/issues/44#issue-985031063)too.


Fixes # ([issue](https://github.com/acicts/BITS21/issues/44#issue-985031063))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ✔] Grammar errors / Typo

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System: Windows 10
* Hardware: i3, 4GB RAM, 1000GB Storage

# Checklist:

- [✔ ] My code follows the style guidelines of this project
- [✔ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ✔] My changes generate no new warnings

# ScreenShots:

*Before* - 
![Screenshot (423)](https://user-images.githubusercontent.com/76873393/131664056-9d86c6f3-385e-4f4f-92e2-ad27a1295a56.png)

*After* -
![Screenshot (423)](https://user-images.githubusercontent.com/76873393/131664098-23b2df39-2848-4900-89b0-1b46eb991b01.png)



